### PR TITLE
Changed from pass-by-copy to pass-by-const-ref. 

### DIFF
--- a/EEPROMVar.h
+++ b/EEPROMVar.h
@@ -24,14 +24,17 @@
 template<typename T> class EEPROMVar 
 {
 	public:
-	  EEPROMVar(T init) {
-		address = EEPROM.getAddress(sizeof(T));	
-		var = init;
 	  }
+	  EEPROMVar(const T& init):
+		var(init),
+		address(EEPROM.getAddress(sizeof(T)))
+	  {
+	  }
+
 	  operator T () { 
 		return var; 
 	  }
-	  EEPROMVar &operator=(T val) {
+	  EEPROMVar &operator=(const T& val) {
 		var = val;
 		return *this;
 	  }


### PR DESCRIPTION
A minor change but could have significant impact for large structures. I believe it makes no difference for built-in types.
