### PR TITLE
Update EEPROMVar.h

### DIFF
--- a/EEPROMVar.h
+++ b/EEPROMVar.h
@@ -27,7 +27,6 @@
 template<typename T> class EEPROMVar 
 {
 	public:
-	  }
 	  EEPROMVar(const T& init):
 		var(init),
 		address(EEPROM.getAddress(sizeof(T)))


### PR DESCRIPTION
Fixed compile error due to extra '}'
