### PR TITLE
Set architectures property to avr

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Extension of the standard Arduino EEPROM library.
 paragraph=Extended for reading and writing basic types, structs, strings, arrays and more.
 category=Data Storage 
 url=http://playground.arduino.cc/Code/EEPROMex
-architectures=* 
+architectures=avr


### PR DESCRIPTION
This library is AVR specific so the previous wildcard value of the `architectures` property in library.properties is incorrect.

This change will cause this library's examples to appear under the **File > Examples > INCOMPATIBLE > EEPROMex** menu when a non-AVR board is selected, which can provide a valuable clue to the user why the library isn't working with that board (e.g. https://github.com/thijse/Arduino-EEPROMEx/issues/19). The Arduino IDE also provides a library mismatch warning but unfortunately this does not currently appear when compilation fails due to an included file not being found (https://github.com/arduino/arduino-builder/issues/228), which is the outcome of attempting to compile this library for a non-AVR board. This issue will hopefully be resolved in a future version of the Arduino IDE.