### PR TITLE
Use correct include syntax

### DIFF
--- a/EEPROMVar.h
+++ b/EEPROMVar.h
@@ -1,4 +1,4 @@
-#include <EEPROMex.h>
+#include "EEPROMex.h"
 
 /*
   EEPROMvar.h - EEPROM variable library


### PR DESCRIPTION
Angle brackets should be used for external includes, guotes for local includes. The former is not critical but the latter is necessary in order to use the library when it's not in one of the standard Arduino libraries folders (such as when bundled with a sketch), where local files included with the angle brackets syntax will not be found in the include search path, causing compilation to fail.