### PR TITLE
Work around problem in <avr/eeprom.h>

### DIFF
--- a/EEPROMex.cpp
+++ b/EEPROMex.cpp
@@ -99,7 +99,11 @@ int EEPROMClassEx::getAddress(int noOfBytes){
  * Check if EEPROM memory is ready to be accessed
  */
 bool EEPROMClassEx::isReady() {
+#if defined(ARDUINO_ARCH_MEGAAVR) //work around a bug in <avr/eeprom.h>
+	return bit_is_clear(NVMCTRL.STATUS,NVMCTRL_EEBUSY_bp);
+#else
 	return eeprom_is_ready();
+#endif
 }
 
 /**


### PR DESCRIPTION
At least as of the avr-gcc package Arduino is distributing as 7.3.0-atmel3.6.1-arduino5 (with latest megaAVR board package, 1.8.5), for megaavr parts,  eeprom_is_ready() is defined as:

```
# define eeprom_is_ready()	bit_is_clear (NVM_STATUS, NVM_NVMBUSY_bp)
```

Those registers do not exist, at least on the megaAVR 0-series (ATmega4809/4808 and smaller flash versions), tinyAVR 0-series or tinyAVR 1-series parts. They meant to check the EEBUSY bit in the NVMCTRL.STATUS register. I don't know who to submit fixes for eeprom.h to, but this change works around the bug in this library, so this will work on megaavr parts (Nano Every, Uno WiFi Rev. 2, and the ATtiny parts, which are supported by https://github.com/SpenceKonde/megaTinyCore)